### PR TITLE
헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
             </ul>
 
             <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
링크는 타임리프 태그로 처리하도록 변경
이렇게 해서 스프링 부트로 띄우지 않은 정적 페이지는 링크 동작을 보여주지 않아서 리소스 접근에 안전하다.
#30 에서 추가한 기능을 헤더 메뉴에 노출시키는 부분을 구현
This closes #33 