### PR TITLE
인증 기능 구현

### DIFF
--- a/src/main/java/com/jisu/projectboard/config/JpaConfig.java
+++ b/src/main/java/com/jisu/projectboard/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.jisu.projectboard.config;
 
+import com.jisu.projectboard.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
 
@@ -13,6 +17,12 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("jisu"); //스프링 시큐리티로 인증 기능을 구현할 때, 수정해야함.
+
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::getUsername);
     }
 }

--- a/src/main/java/com/jisu/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/jisu/projectboard/config/SecurityConfig.java
@@ -1,8 +1,18 @@
 package com.jisu.projectboard.config;
 
+import com.jisu.projectboard.dto.UserAccountDto;
+import com.jisu.projectboard.dto.security.BoardPrincipal;
+import com.jisu.projectboard.repository.UserAccountRepository;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -11,8 +21,39 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-                .formLogin();
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers(
+                                HttpMethod.GET,
+                                "/",
+                                "/articles",
+                                "/articles/search-hashtag"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin().and()
+                .logout()
+                .logoutSuccessUrl("/")
+                .and();
         return http.build();
+    }
+
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+//    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)
+                .map(UserAccountDto::from)
+                .map(BoardPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - username: " + username));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/com/jisu/projectboard/controller/ArticleCommentController.java
+++ b/src/main/java/com/jisu/projectboard/controller/ArticleCommentController.java
@@ -2,8 +2,10 @@ package com.jisu.projectboard.controller;
 
 import com.jisu.projectboard.dto.UserAccountDto;
 import com.jisu.projectboard.dto.request.ArticleCommentRequest;
+import com.jisu.projectboard.dto.security.BoardPrincipal;
 import com.jisu.projectboard.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,17 +20,14 @@ public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
     @PostMapping("/new")
-    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
-
-        articleCommentService.saveArticleComment(articleCommentRequest.toDto(UserAccountDto.of(
-                "jisu", "1234", "jisu@email.com", null, null
-        )));
+    public String postNewArticleComment(@AuthenticationPrincipal BoardPrincipal boardPrincipal, ArticleCommentRequest articleCommentRequest) {
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
         return "redirect:/articles/" + articleCommentRequest.getArticleId();
     }
 
     @PostMapping("/{commentId}/delete")
-    public String deleteArticleComment(@PathVariable long commentId, long articleId) {
-        articleCommentService.deleteArticleComment(commentId);
+    public String deleteArticleComment(@PathVariable long commentId, @AuthenticationPrincipal BoardPrincipal boardPrincipal, long articleId) {
+        articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
         return "redirect:/articles/" + articleId;
     }
 }

--- a/src/main/java/com/jisu/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/jisu/projectboard/controller/ArticleController.java
@@ -7,6 +7,7 @@ import com.jisu.projectboard.dto.UserAccountDto;
 import com.jisu.projectboard.dto.request.ArticleRequest;
 import com.jisu.projectboard.dto.response.ArticleResponse;
 import com.jisu.projectboard.dto.response.ArticleWithCommentsResponse;
+import com.jisu.projectboard.dto.security.BoardPrincipal;
 import com.jisu.projectboard.service.ArticleService;
 import com.jisu.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
@@ -77,11 +79,8 @@ public class ArticleController {
     }
 
     @PostMapping("/form")
-    public String postNewArticle(ArticleRequest articleRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.saveArticle(articleRequest.toDto(UserAccountDto.of(
-                "jisu", "asdf1234", "jisu@mail.com", "Jisu", "memo"
-        )));
+    public String postNewArticle(ArticleRequest articleRequest, @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles";
     }
@@ -96,20 +95,16 @@ public class ArticleController {
         return "articles/form";
     }
 
-    @PostMapping ("/{articleId}/form")
-    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.updateArticle(articleId, articleRequest.toDto(UserAccountDto.of(
-                "jisu", "asdf1234", "jisu@mail.com", "jisu", "memo"
-        )));
+    @PostMapping("/{articleId}/form")
+    public String updateArticle(@PathVariable Long articleId, @AuthenticationPrincipal BoardPrincipal boardPrincipal, ArticleRequest articleRequest) {
+        articleService.updateArticle(articleId, articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping ("/{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(@PathVariable Long articleId, @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleService.deleteArticle(articleId, boardPrincipal.getUsername());
 
         return "redirect:/articles";
     }

--- a/src/main/java/com/jisu/projectboard/domain/Article.java
+++ b/src/main/java/com/jisu/projectboard/domain/Article.java
@@ -61,7 +61,7 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof Article)) return false;
         Article article = (Article) o;
         return getId() != null && getId().equals(article.getId());
     }

--- a/src/main/java/com/jisu/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/jisu/projectboard/domain/ArticleComment.java
@@ -50,7 +50,7 @@ public class ArticleComment extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if(!(o instanceof ArticleComment)) return false;
         ArticleComment that = (ArticleComment) o;
         return getId() != null && getId().equals(that.getId());
     }

--- a/src/main/java/com/jisu/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/jisu/projectboard/domain/UserAccount.java
@@ -52,7 +52,7 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if(!(o instanceof  UserAccount)) return false;
         UserAccount that = (UserAccount) o;
         return getUserId() != null && getUserId().equals(that.getUserId());
     }

--- a/src/main/java/com/jisu/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/jisu/projectboard/dto/response/ArticleCommentResponse.java
@@ -13,10 +13,11 @@ public class ArticleCommentResponse {
     private final LocalDateTime createdAt;
     private final String email;
     private final String nickname;
+    private final String userId;
 
 
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -32,7 +33,8 @@ public class ArticleCommentResponse {
                 dto.getContent(),
                 dto.getCreatedAt(),
                 dto.getUserAccountDto().getEmail(),
-                nickname
+                nickname,
+                dto.getUserAccountDto().getUserId()
         );
     }
 }

--- a/src/main/java/com/jisu/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/jisu/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -18,10 +18,11 @@ public class ArticleWithCommentsResponse {
     private final LocalDateTime createdAt;
     private final String email;
     private final String nickname;
+    private final String userId;
     private final Set<ArticleCommentResponse> articleCommentResponse;
 
-    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
     }
 
     public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
@@ -38,6 +39,7 @@ public class ArticleWithCommentsResponse {
                 dto.getCreatedAt(),
                 dto.getUserAccountDto().getEmail(),
                 nickname,
+                dto.getUserAccountDto().getUserId(),
                 dto.getArticleCommentDtos().stream()
                         .map(ArticleCommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/jisu/projectboard/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/jisu/projectboard/dto/security/BoardPrincipal.java
@@ -1,0 +1,105 @@
+package com.jisu.projectboard.dto.security;
+
+import com.jisu.projectboard.dto.UserAccountDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+public class BoardPrincipal implements UserDetails {
+
+    private String username;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private String email;
+    private String nickname;
+    private String memo;
+
+    public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+        Set<RoleType>  roleTypes = Set.of(RoleType.USER);
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::name)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    public static BoardPrincipal from(UserAccountDto userAccountDto) {
+        return BoardPrincipal.of(
+                userAccountDto.getUserId(),
+                userAccountDto.getUserPassword(),
+                userAccountDto.getEmail(),
+                userAccountDto.getNickname(),
+                userAccountDto.getMemo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                username,
+                password,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public enum RoleType {
+        USER("ROLE_USER");
+
+        @Getter
+        private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+
+}

--- a/src/main/java/com/jisu/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/jisu/projectboard/repository/ArticleCommentRepository.java
@@ -18,6 +18,8 @@ public interface ArticleCommentRepository extends JpaRepository<ArticleComment, 
 
     List<ArticleComment> findByArticle_Id(Long articleId);
 
+    void deleteByIdAndUserAccount_UserId(Long articleCommentId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/jisu/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/jisu/projectboard/repository/ArticleRepository.java
@@ -23,6 +23,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
 
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userid);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/jisu/projectboard/service/ArticleCommentService.java
+++ b/src/main/java/com/jisu/projectboard/service/ArticleCommentService.java
@@ -54,8 +54,8 @@ public class ArticleCommentService {
         }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
-        articleCommentRepository.deleteById(articleCommentId);
+    public void deleteArticleComment(Long articleCommentId, String userId) {
+        articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
 }

--- a/src/main/java/com/jisu/projectboard/service/ArticleService.java
+++ b/src/main/java/com/jisu/projectboard/service/ArticleService.java
@@ -75,20 +75,24 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            if (dto.getTitle() != null) {
-                article.setTitle(dto.getTitle());
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.getUserAccountDto().getUserId());
+            if (article.getUserAccount().equals(userAccount)) {
+                if (dto.getTitle() != null) {
+                    article.setTitle(dto.getTitle());
+                }
+                if (dto.getContent() != null) {
+                    article.setContent(dto.getContent());
+                }
+                article.setHashtag(dto.getHashtag());
+                System.out.println("articleEnd = " + article);
             }
-            if (dto.getContent() != null) {
-                article.setContent(dto.getContent());
-            }
-            article.setHashtag(dto.getHashtag());
         } catch (EntityNotFoundException e) {
-            log.warn("게시글 업데이트 실패. 게시글을 찾을 수 없습니다. -dto: {}", dto);
+            log.warn("게시글 업데이트 실패. 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다. - {}", e.getLocalizedMessage());
         }
     }
 
-    public void deleteArticle(long articleId) {
-        articleRepository.deleteById(articleId);
+    public void deleteArticle(long articleId, String userId) {
+        articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     public long getArticleCount() {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,11 +2,11 @@
 --  TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('jisu', 'asdf1234', 'jisu', 'jisu@mail.com', 'I am jisu.', now(), 'jisu', now(), 'jisu')
+values ('jisu', '{noop}asdf1234', 'jisu', 'jisu@mail.com', 'I am jisu.', now(), 'jisu', now(), 'jisu')
 ;
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('jisu2', 'asdf1234', 'jisu2', 'jisu2@mail.com', 'I am jisu2.', now(), 'jisu2', now(), 'jisu2')
+values ('jisu2', '{noop}asdf1234', 'jisu2', 'jisu2@mail.com', 'I am jisu2.', now(), 'jisu2', now(), 'jisu2')
 ;
 
 -- 123 게시글

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -74,20 +74,25 @@
                                     Lorem ipsum dolor sit amet
                                 </p>
                             </div>
-                            <div class="col-2 mb-3">
+                            <div class="col-2 mb-3 align-self-center">
                                 <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                             </div>
                         </div>
                     </form>
                 </li>
                 <li>
-                    <div>
-                        <strong>jisu2</strong>
-                        <small><time>2022-01-01</time></small>
-                        <p>
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                            Lorem ipsum dolor sit amet
-                        </p>
+                    <div class="row">
+                        <div class="col-md-10 col-lg-9">
+                            <strong>jisu2</strong>
+                            <small><time>2022-01-01</time></small>
+                            <p>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                                Lorem ipsum dolor sit amet
+                            </p>
+                        </div>
+                        <div class="col-2 mb-3 align-self-center">
+                            <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
+                        </div>
                     </div>
                 </li>
             </ul>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -11,7 +11,7 @@
         <attr sel="#hashtag" th:text="*{hashtag}" />
         <attr sel="#article-content/pre" th:text="*{content}" />
 
-        <attr sel="#article-buttons">
+        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
@@ -28,6 +28,7 @@
                 <attr sel="div/strong" th:text="${articleComment.nickname}" />
                 <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
                 <attr sel="div/p" th:text="${articleComment.content}" />
+                <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
             </attr>
         </attr>
     </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -53,7 +53,7 @@
             </attr>
         </attr>
 
-        <attr sel="#write-article" th:href="@{/articles/form}" />
+        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,8 +14,10 @@
             </ul>
 
             <div class="text-end">
-                <button type="button" class="btn btn-outline-light me-2">Login</button>
-                <button type="button" class="btn btn-warning">Sign-up</button>
+                <span id="username" class="text-white me-2">username</span>
+                <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
+                <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
+                <a role="button" id="sign-up" class="btn btn-warning">Sign-up</a>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -2,4 +2,8 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
+    <attr sel="#sign-up" sec:authorize="!isAuthenticated()" th:href="@{/logout}" />
 </thlogic>

--- a/src/test/java/com/jisu/projectboard/config/TestSecurityConfig.java
+++ b/src/test/java/com/jisu/projectboard/config/TestSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.jisu.projectboard.config;
+
+import com.jisu.projectboard.domain.UserAccount;
+import com.jisu.projectboard.repository.UserAccountRepository;
+import org.mockito.ArgumentMatchers;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean private UserAccountRepository userAccountRepository;
+
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(userAccountRepository.findById(ArgumentMatchers.anyString())).willReturn(Optional.of(UserAccount.of(
+                "jisuTest",
+                "pw",
+                "jisu-test@email.com",
+                "jisu-test",
+                "test memo"
+                )));
+    }
+}

--- a/src/test/java/com/jisu/projectboard/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/jisu/projectboard/controller/ArticleCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.jisu.projectboard.controller;
 
 import com.jisu.projectboard.config.SecurityConfig;
+import com.jisu.projectboard.config.TestSecurityConfig;
 import com.jisu.projectboard.dto.ArticleCommentDto;
 import com.jisu.projectboard.dto.request.ArticleCommentRequest;
 import com.jisu.projectboard.service.ArticleCommentService;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 
@@ -27,7 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 
 @DisplayName("View 컨트롤러 - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
 
@@ -42,6 +45,7 @@ class ArticleCommentControllerTest {
     }
 
 
+    @WithUserDetails(value = "jisuTest", setupBefore = TestExecutionEvent.TEST_EXECUTION, userDetailsServiceBeanName = "userDetailsService")
     @DisplayName("[view][POST] 댓글 등록 - 정상 호출")
     @Test
     void givenArticleCommentInfo_whenRequesting_thenSavesNewArticleComment() throws Exception {
@@ -63,13 +67,15 @@ class ArticleCommentControllerTest {
         then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
     }
 
+    @WithUserDetails(value = "jisuTest", setupBefore = TestExecutionEvent.TEST_EXECUTION, userDetailsServiceBeanName = "userDetailsService")
     @DisplayName("[view][GET] 댓글 삭제 - 정상 호출")
     @Test
     void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
         // Given
         long articleId = 1L;
         long articleCommentId = 1L;
-        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId);
+        String userId = "jisuTest";
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
         // When & Then
         mvc.perform(
@@ -81,6 +87,6 @@ class ArticleCommentControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
-        then(articleCommentService).should().deleteArticleComment(articleCommentId);
+        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
     }
 }

--- a/src/test/java/com/jisu/projectboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/jisu/projectboard/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.jisu.projectboard.controller;
 
 import com.jisu.projectboard.config.SecurityConfig;
+import com.jisu.projectboard.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 인증")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(Void.class)
 public class AuthControllerTest {
 

--- a/src/test/java/com/jisu/projectboard/controller/IndexControllerTest.java
+++ b/src/test/java/com/jisu/projectboard/controller/IndexControllerTest.java
@@ -1,6 +1,7 @@
 package com.jisu.projectboard.controller;
 
 import com.jisu.projectboard.config.SecurityConfig;
+import com.jisu.projectboard.config.TestSecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -14,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(IndexController.class)
 class IndexControllerTest {
 

--- a/src/test/java/com/jisu/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/jisu/projectboard/repository/JpaRepositoryTest.java
@@ -7,15 +7,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
@@ -72,7 +77,7 @@ class JpaRepositoryTest {
         //update쿼리 보기위해 flush해줌
 
         //then
-        assertThat(findArticle).hasFieldOrPropertyWithValue("hashtag", updatedHashtag);
+        assertThat(savedArticle).hasFieldOrPropertyWithValue("hashtag", updatedHashtag);
     }
 
     @DisplayName("delete 테스트")
@@ -92,5 +97,12 @@ class JpaRepositoryTest {
         assertThat(articleCommentRepository.count()).isEqualTo(articleCommentCount -deletedCommentSize);
     }
 
-
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig {
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("jisu");
+        }
+    }
 }

--- a/src/test/java/com/jisu/projectboard/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/jisu/projectboard/service/ArticleCommentServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
@@ -126,13 +127,14 @@ class ArticleCommentServiceTest {
     void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
         // Given
         Long articleCommentId = 1L;
-        willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+        String userId = "jisu";
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 
         // When
-        sut.deleteArticleComment(articleCommentId);
+        sut.deleteArticleComment(articleCommentId, userId);
 
         // Then
-        then(articleCommentRepository).should().deleteById(articleCommentId);
+        then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
 

--- a/src/test/java/com/jisu/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/jisu/projectboard/service/ArticleServiceTest.java
@@ -195,6 +195,7 @@ class ArticleServiceTest {
         Article article = createArticle();
         ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#springboot");
         given(articleRepository.getReferenceById(dto.getId())).willReturn(article);
+        given(userAccountRepository.getReferenceById(dto.getUserAccountDto().getUserId())).willReturn(dto.getUserAccountDto().toEntity());
 
         // When
         sut.updateArticle(dto.getId(), dto);
@@ -205,6 +206,7 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", dto.getContent())
                 .hasFieldOrPropertyWithValue("hashtag", dto.getHashtag());
         then(articleRepository).should().getReferenceById(dto.getId());
+        then(userAccountRepository).should().getReferenceById(dto.getUserAccountDto().getUserId());
     }
 
     @DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
@@ -226,13 +228,14 @@ class ArticleServiceTest {
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
         Long articleId = 1L;
-        willDoNothing().given(articleRepository).deleteById(articleId);
+        String userId = "jisuTest";
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
 
         // When
-        sut.deleteArticle(1L);
+        sut.deleteArticle(1L, userId);
 
         // Then
-        then(articleRepository).should().deleteById(articleId);
+        then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")


### PR DESCRIPTION
시큐리티 설정과 자바 코드 구현
스프링 부트 2.7 과 가이드에 맞춰서
시큐리티 설정을 적용하고, 인증 정보를 db로부터 부르는 빈과
패스워드 인코더 빈까지 등록
영향 받는 부분을 서비스 코드와 컨트롤러에 반영

equla() 재정의 
JPA Entity의 equals()와 hashCode()를 IDE(ex. IntelliJ)로 기본 자동 생성할때  getClass()로 비교되는 것으로 생성된다.
azy fetch는 해당 entity를 상속하는 Proxy 객체를 반환하기 때문에 getClass()가 User 객체가 될수 없어 equals 비교가 실패하게 된다.
해결책은 instanceof로 override 해주어야 한다

패스워드 인코더가 인식할 수 있게 패스워드 정보 수정
앞머리에 `{encoding-info}`와 같이 암호화 정보를 넣어줘야
패스워드 인코더가 읽을 수 있다.
이에 패스워드 데이터를 알맞게 수정함

 수정, 삭제를 할 때 해당 사용자가 맞는지 확인하기 위한 응답 정보 추가
인증 정보의 `userId`와
해당 게시글/댓글의 작성자 `userId`가 동일한지 알려면
응답에서 `userId`를 내려줘야 함
이를 response dto 에 반영

인증 기능의 뷰 연결
게시글/댓글의 등록, 수정, 삭제 버튼이
적절한 상황에서 노출되고, 숨겨지게끔 함
헤더에도 인증 정보에 따라 표현이 달라지게끔 수정
로그인 하면 헤더에 인증 사용자 id와 알맞는 버튼을 볼 수 있음

This closes #41 